### PR TITLE
Specify build context, Dockerfile, and target platforms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   chesshub-ui:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - linux/arm64
+        - linux/amd64
     container_name: chesshub-ui
     image: ${DOCKER_USERNAME}/chesshub-ui:${DOCKER_IMAGE_VERSION}
     ports:


### PR DESCRIPTION
Added explicit context and Dockerfile path in the build configuration. Defined supported platforms (linux/arm64 and linux/amd64) to improve cross-platform compatibility.